### PR TITLE
feat: Expose `CONTENT_MAPPINGS` and `getContentTypeFromExtension`

### DIFF
--- a/lib/RdfSerializer.ts
+++ b/lib/RdfSerializer.ts
@@ -12,7 +12,7 @@ import {
 export class RdfSerializer<Q extends RDF.BaseQuad = RDF.Quad>  {
 
   // tslint:disable:object-literal-sort-keys
-  private static readonly CONTENT_MAPPINGS: { [id: string]: string } = {
+  public static readonly CONTENT_MAPPINGS: { [id: string]: string } = {
     ttl      : "text/turtle",
     turtle   : "text/turtle",
     nt       : "application/n-triples",
@@ -99,7 +99,7 @@ export class RdfSerializer<Q extends RDF.BaseQuad = RDF.Quad>  {
    * @param {string} path A path.
    * @return {string} A content type or the empty string.
    */
-  protected getContentTypeFromExtension(path: string): string {
+  public getContentTypeFromExtension(path: string): string {
     const dotIndex = path.lastIndexOf('.');
     if (dotIndex >= 0) {
       const ext = path.substr(dotIndex);


### PR DESCRIPTION
It is quite useful for consumers to know what they can parse in advance, for in order to properly handle content negotiation logic