### PR TITLE
chore: dont use node streams

### DIFF
--- a/lib/RdfSerializer.ts
+++ b/lib/RdfSerializer.ts
@@ -1,6 +1,6 @@
 import { ActionContext, Actor } from "@comunica/core";
 import * as RDF from "@rdfjs/types";
-import { PassThrough } from "stream";
+import { PassThrough } from "readable-stream";
 import {
   MediatorRdfSerializeHandle,
   MediatorRdfSerializeMediaTypes

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@comunica/mediator-combine-union": "^2.0.1",
     "@comunica/mediator-race": "^2.0.1",
     "@rdfjs/types": "*",
+    "readable-stream": "^4.3.0",
     "stream-to-string": "^1.1.0"
   }
 }


### PR DESCRIPTION
Uses readable stream instead of node stream.

Notes: Before and after making the changes in this PR, jest emits the following error (running on node 18).
```
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
```